### PR TITLE
Add potential Macports task path

### DIFF
--- a/Sources/Repositories/Taskwarrior.swift
+++ b/Sources/Repositories/Taskwarrior.swift
@@ -93,9 +93,13 @@ public class TaskwarriorRepository {
         let process = Process.init()
         defer { process.terminate() }
 
-        var taskBinaryPath = "/usr/local/bin/task"
+        var taskBinaryPath = "/usr/local/bin/task" // Default Taskwarrior path.
         if !FileManager.default.isExecutableFile(atPath: taskBinaryPath) {
-            taskBinaryPath = "/opt/homebrew/bin/task"
+            if FileManager.default.isExecutableFile(atPath: "/opt/homebrew/bin/task") {
+               taskBinaryPath = "/opt/homebrew/bin/task" //If Taskwarrior is Homebrew installed
+            } else if FileManager.default.isExecutableFile(atPath: "/opt/local/bin/task") {
+               taskBinaryPath = "/opt/local/bin/task" //If Taskwarrior is Macports installed
+        }
         }
 
         process.launchPath = taskBinaryPath


### PR DESCRIPTION
Hi there, I'd previously installed `task` via Macports. When trying `taskwarrior-reminders`, the launchd execution kept crashing. It also crashed when run directly from the command line as suggested in #10 . 

So, I added the Macports path to the appropriate logic as suggested by https://github.com/blampe/taskwarrior-reminders/pull/7

It seems to be not crashing not, but unclear if it is fully working. Will follow up in an issue if I can sort it out!